### PR TITLE
Use `ptrdiff_t` instead of `ssize_t`

### DIFF
--- a/include/rigtorp/SPSCQueue.h
+++ b/include/rigtorp/SPSCQueue.h
@@ -24,6 +24,7 @@ SOFTWARE.
 
 #include <atomic>
 #include <cassert>
+#include <cstddef>
 #include <stdexcept>
 #include <type_traits>
 
@@ -43,7 +44,7 @@ public:
     assert(alignof(SPSCQueue<T>) >= kCacheLineSize);
     assert(reinterpret_cast<char *>(&tail_) -
                reinterpret_cast<char *>(&head_) >=
-           static_cast<ptrdiff_t>(kCacheLineSize));
+           static_cast<std::ptrdiff_t>(kCacheLineSize));
   }
 
   ~SPSCQueue() {

--- a/include/rigtorp/SPSCQueue.h
+++ b/include/rigtorp/SPSCQueue.h
@@ -43,7 +43,7 @@ public:
     assert(alignof(SPSCQueue<T>) >= kCacheLineSize);
     assert(reinterpret_cast<char *>(&tail_) -
                reinterpret_cast<char *>(&head_) >=
-           static_cast<ssize_t>(kCacheLineSize));
+           static_cast<ptrdiff_t>(kCacheLineSize));
   }
 
   ~SPSCQueue() {


### PR DESCRIPTION
`ssize_t` is a POSIX extension and is not supported on MSVC, use `ptrdiff_t` instead