### PR TITLE
Use 'ptrdiff_t' instead of 'ssize_t' in 'size()' method.

### DIFF
--- a/include/rigtorp/SPSCQueue.h
+++ b/include/rigtorp/SPSCQueue.h
@@ -139,12 +139,12 @@ public:
   }
 
   size_t size() const noexcept {
-    ssize_t diff = head_.load(std::memory_order_acquire) -
-                   tail_.load(std::memory_order_acquire);
+    std::ptrdiff_t diff = head_.load(std::memory_order_acquire) -
+                          tail_.load(std::memory_order_acquire);
     if (diff < 0) {
       diff += capacity_;
     }
-    return diff;
+    return static_cast<size_t>(diff);
   }
 
   bool empty() const noexcept { return size() == 0; }


### PR DESCRIPTION
Addition to [this](https://github.com/rigtorp/SPSCQueue/commit/10c00a5c0f1bcfcd4f4e135d143f00b409254026) commit.