### PR TITLE
Add try_pop() = front() + pop() operation

### DIFF
--- a/src/SPSCQueueTest.cpp
+++ b/src/SPSCQueueTest.cpp
@@ -71,6 +71,8 @@ int main(int argc, char *argv[]) {
   {
     SPSCQueue<TestType> q(11);
     assert(q.front() == nullptr);
+    TestType t;
+    assert(!q.try_pop(t));
     assert(q.size() == 0);
     assert(q.empty() == true);
     assert(q.capacity() == 11);
@@ -80,14 +82,17 @@ int main(int argc, char *argv[]) {
     assert(q.front() != nullptr);
     assert(q.size() == 10);
     assert(q.empty() == false);
-    assert(TestType::constructed.size() == 10);
+    assert(TestType::constructed.size() == 11);
     assert(q.try_emplace() == false);
     q.pop();
     assert(q.size() == 9);
-    assert(TestType::constructed.size() == 9);
+    assert(TestType::constructed.size() == 10);
     q.pop();
     assert(q.try_emplace() == true);
-    assert(TestType::constructed.size() == 9);
+    assert(TestType::constructed.size() == 10);
+    assert(q.try_pop(t));
+    assert(q.try_emplace() == true);
+    assert(TestType::constructed.size() == 10);
   }
   assert(TestType::constructed.size() == 0);
 


### PR DESCRIPTION
...as found in MPMCQueue. This is a very common operation. Invoking front() and pop() subsequently would be inefficient.

Hi, Erik. If you agree I would like to propose to use your implementation for some use cases in [Mixxx](https://github.com/uklotzde/mixxx/tree/rigtorp_spscqueue). Maintaining our own custom SPSC queue implementation doesn't make any sense and the C ring buffer from PortAudio that we also use is error-prone and dangerous for non-POD types.

Do you have any plans to align the API of both SPSCQueue and MPMCQueue?