### PR TITLE
Bug fix for #35

### DIFF
--- a/include/rigtorp/SPSCQueue.h
+++ b/include/rigtorp/SPSCQueue.h
@@ -186,6 +186,17 @@ public:
     if (nextReadIdx == capacity_) {
       nextReadIdx = 0;
     }
+    // bug fix: don't allow writeIdxCache_ to fall behind readIdx_
+    //
+    // Without this fix, the assertion in the example below will fail:
+    //
+    // SPSCQueue<int> q(16);
+    // q.emplace(0);
+    // q.pop();
+    // assert(q.front() == nullptr);
+    if (readIdx == writeIdxCache_) {
+      writeIdxCache_ = nextReadIdx;
+    }
     readIdx_.store(nextReadIdx, std::memory_order_release);
   }
 


### PR DESCRIPTION
If an item is popped without ever having been accessed via front(), front() may subsequently return non-null even though the queue is empty.

The following code demonstrates the bug:
```
SPSCQueue<int> q(16);
q.emplace(0);
q.pop();
assert(q.front() == nullptr); // prior to the fix, this assertion fails

```